### PR TITLE
Remove 'car' as keyword for :bus:

### DIFF
--- a/extension/emojis.json
+++ b/extension/emojis.json
@@ -2115,7 +2115,7 @@
     "category": "travelandplaces"
   },
   "bus": {
-    "keywords": ["car", "vehicle", "transportation"],
+    "keywords": ["vehicle", "transportation"],
     "char": "🚌",
     "category": "travelandplaces"
   },


### PR DESCRIPTION
Fixes https://github.com/notwaldorf/emoji-translate/issues/12.

The issue made sense to me, so I thought I'd fix it and open a pull request! I :heart: emoji and I support this project :grin: 