### PR TITLE
Don't use null emojis

### DIFF
--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -1,5 +1,9 @@
 var allEmojis;
 var SYMBOLS = '!"#$%&\'()*+,-./:;<=>?@[]^_`{|}~';
+var defaultOptions = {
+  useFlags: true, //Whether to use flag emoji
+  minLength: 0 //Minimum length of a word to convert to emoji
+};
 
 /**
  * Fires an emoji:ready event when the list of emojis has been loaded.
@@ -23,9 +27,12 @@ var SYMBOLS = '!"#$%&\'()*+,-./:;<=>?@[]^_`{|}~';
 /**
  * Returns a possibly translated english word to emoji, ready for display.
  * @param {String} word The word to be translated
+ * @params {Object} options Options object. See defaultOptions for doc
  * @returns {HTMLElement} A <span> element containing the translated word.
  */
-function translateWord(word) {
+function translateWord(word, options) {
+  options = options || defaultOptions;
+  console.log(options);
   var node = document.createElement('span');
 
   // Punctuation blows. Get all the punctuation at the start and end of the word.
@@ -41,9 +48,8 @@ function translateWord(word) {
     lastSymbol += word[word.length - 1];
     word = word.slice(0, word.length - 1);
   }
-
   // If it's already an emoji, return it;
-  var emoji = getMeAnEmoji(word);
+  var emoji = (word.length >= options.minLength) ? getMeAnEmoji(word, options) : [word];
 
   if (emoji === '')
     return null;
@@ -66,9 +72,10 @@ function translateWord(word) {
 /**
  * Returns the emoji equivalent of an english word.
  * @param {String} word The word to be translated
+ * @param {Object} options Options object. See defaultOptions for doc
  * @returns {String} The emoji character representing this word, or '' if one doesn't exist.
  */
-function getMeAnEmoji(word) {
+function getMeAnEmoji(word, options) {
   var originalWord = word;
   word = word.trim().toLowerCase();
 
@@ -94,6 +101,9 @@ function getMeAnEmoji(word) {
 
   // Go through all the things and find the first one that matches.
   for (var emoji in allEmojis) {
+    //Check if compatible with options
+    if (!options.useFlags && allEmojis[emoji].category == 'flags')
+      continue;
     var words = allEmojis[emoji].keywords;
     if (word == allEmojis[emoji].char ||
         emoji == word || (emoji == word + '_face' ) ||

--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -2,7 +2,8 @@ var allEmojis;
 var SYMBOLS = '!"#$%&\'()*+,-./:;<=>?@[]^_`{|}~';
 var defaultOptions = {
   excludedCategories: [], //Array of categories of emoji to ignore
-  minLength: 0 //Minimum length of a word to convert to emoji
+  minLength: 0, //Minimum length of a word to convert to emoji,
+  keepWord: false //Whether to append the emoji to the output word rather than overwriting it
 };
 
 /**
@@ -54,14 +55,15 @@ function translateWord(word, options) {
     return null;
 
   var node;
+  var appendWord = (options.keepWord && emoji != word) ? word : '';
   if (emoji.length === 1) {
     node = document.createElement('span');
-    node.innerHTML = firstSymbol + emoji + lastSymbol + ' ';
+    node.innerHTML = appendWord + firstSymbol + emoji + lastSymbol + ' ';
   } else {
     node = document.createElement('select');
     for (var i = 0; i < emoji.length; i++) {
       var option = document.createElement('option');
-      option.innerHTML = firstSymbol + emoji[i] + lastSymbol + ' ';
+      option.innerHTML = appendWord + firstSymbol + emoji[i] + lastSymbol + ' ';
       node.appendChild(option);
     }
   }

--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -85,6 +85,8 @@ function getMeAnEmoji(word) {
   var maybePlural = (word.length == 1) ? '' : word + 's';
 
   var maybeVerbed = (word.indexOf('ing') == -1) ? '' : word.substr(0, word.length-3);
+  //Check if past tense of a verb i.e. -ed
+  var maybePastTense = (word.substr(word.length - 2, 2) == 'ed') ? word.substr(0, word.length-2) : '';
 
   // Go through all the things and find the first one that matches.
   var useful = [];
@@ -98,7 +100,8 @@ function getMeAnEmoji(word) {
         (words && words.indexOf(word) >= 0) ||
         (words && words.indexOf(maybeSingular) >= 0) ||
         (words && words.indexOf(maybePlural) >= 0) ||
-        (words && words.indexOf(maybeVerbed) >= 0)) {
+        (words && words.indexOf(maybeVerbed) >= 0) ||
+        (words && words.indexOf(maybePastTense) >= 0)) {
       if (allEmojis[emoji].char !== null)
         useful.push(allEmojis[emoji].char);
     }

--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -99,7 +99,8 @@ function getMeAnEmoji(word) {
         (words && words.indexOf(maybeSingular) >= 0) ||
         (words && words.indexOf(maybePlural) >= 0) ||
         (words && words.indexOf(maybeVerbed) >= 0)) {
-      useful.push(allEmojis[emoji].char);
+      if (allEmojis[emoji].char !== null)
+        useful.push(allEmojis[emoji].char);
     }
   }
 

--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -1,7 +1,7 @@
 var allEmojis;
 var SYMBOLS = '!"#$%&\'()*+,-./:;<=>?@[]^_`{|}~';
 var defaultOptions = {
-  useFlags: true, //Whether to use flag emoji
+  excludedCategories: [], //Array of categories of emoji to ignore
   minLength: 0 //Minimum length of a word to convert to emoji
 };
 
@@ -32,7 +32,6 @@ var defaultOptions = {
  */
 function translateWord(word, options) {
   options = options || defaultOptions;
-  console.log(options);
   var node = document.createElement('span');
 
   // Punctuation blows. Get all the punctuation at the start and end of the word.
@@ -102,7 +101,7 @@ function getMeAnEmoji(word, options) {
   // Go through all the things and find the first one that matches.
   for (var emoji in allEmojis) {
     //Check if compatible with options
-    if (!options.useFlags && allEmojis[emoji].category == 'flags')
+    if (options.excludedCategories.indexOf(allEmojis[emoji].category) > -1)
       continue;
     var words = allEmojis[emoji].keywords;
     if (word == allEmojis[emoji].char ||

--- a/emoji-translate.js
+++ b/emoji-translate.js
@@ -69,6 +69,7 @@ function translateWord(word) {
  * @returns {String} The emoji character representing this word, or '' if one doesn't exist.
  */
 function getMeAnEmoji(word) {
+  var originalWord = word;
   word = word.trim().toLowerCase();
 
   if (!word || word === '' || word === 'it')
@@ -109,7 +110,7 @@ function getMeAnEmoji(word) {
 
   // Add the word itself if there was no emoji translation.
   if (useful.length === 0)
-    useful.push(word);
+    useful.push(originalWord);
 
   return (useful.length === 0) ? '' : useful;
 };


### PR DESCRIPTION
There's a few emoji in emojilib's emojis.json where char is null.

Currently, when emoji-translate resolves a word to one of these emojis, the whole word is dropped from the output. This pull request checks if char is null before adding to the matches array.