### PR TITLE
Give the 'COPY TO CLIPBOARD' button a width

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
     vertical-align: middle;
     font-size: 14px;
     margin: 20px;
+    width: 180px;
   }
   #footer {
     margin-top: 100px;


### PR DESCRIPTION
hello :tada: !

Just a small PR. I noticed the 'COPY TO CLIPBOARD' button on the example site is resizing on click. I've added a `width: 180px;` to the css to keep the size consistant.

I made the button slightly bigger than it was before for an error case.

---

## Before
![emoji-translate-old](https://user-images.githubusercontent.com/13941027/36152771-097f3bc8-10c4-11e8-8113-9b6dd0fcf19b.gif)

## After
![emoji-translate-new](https://user-images.githubusercontent.com/13941027/36152798-1e5db02e-10c4-11e8-817a-2f3f2bdb7525.gif)

## Error
![image](https://user-images.githubusercontent.com/13941027/36152870-5a285e4c-10c4-11e8-9562-8cdcdd2dbe6a.png)

